### PR TITLE
Fix memory leak in fuzz_array.c caused by cupsArrayDup

### DIFF
--- a/projects/cups/fuzzer/fuzz_array.c
+++ b/projects/cups/fuzzer/fuzz_array.c
@@ -153,6 +153,10 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     if (text != saved[i])
       break;
   }
+	
+  for (char *elem = (char *)cupsArrayGetFirst(dup_array); elem != NULL; elem = (char *)cupsArrayGetNext(dup_array)) {
+    free(elem);  // Explicitly free each strdup'd string
+  }
 
   // Delete the arrays...
   cupsArrayDelete(array);


### PR DESCRIPTION
### Overview
This patch fixes a 2-byte memory leak in the existing CUPS fuzzer (`fuzz_array.c`). The leak occurred because `cupsArrayDup()` duplicates each element, but those new allocations weren’t freed before deleting the array.

### Changes
- After calling `cupsArrayDup()`, added a loop to iterate over every element in the duplicated array and call `free()` on each one.
- Verified locally using:
python3 infra/helper.py run_fuzzer cups fuzz_array
