### PR TITLE
Support oss-fuzz-gen harnesses by avoiding nested directories

### DIFF
--- a/projects/cups-filters/oss_fuzz_build.sh
+++ b/projects/cups-filters/oss_fuzz_build.sh
@@ -42,7 +42,7 @@ cp $SRC/fuzzing/projects/cups-filters/fuzzer/patch_qpdf_xobject $SRC/cups-filter
 pushd $SRC/fuzzing/projects/cups-filters/
 # Show fuzzer version
 echo "OpenPrinting/fuzzing version: $(git rev-parse HEAD)"
-cp -r $SRC/fuzzing/projects/cups-filters/fuzzer $SRC/cups-filters/ossfuzz/
+cp -r $SRC/fuzzing/projects/cups-filters/fuzzer/. $SRC/cups-filters/ossfuzz/
 popd
 
 # Build cups-filters

--- a/projects/cups/oss_fuzz_build.sh
+++ b/projects/cups/oss_fuzz_build.sh
@@ -27,7 +27,7 @@ fi
 pushd $SRC/fuzzing/projects/cups/
 # Show fuzzer version
 echo "OpenPrinting/fuzzing version: $(git rev-parse HEAD)"
-cp -r $SRC/fuzzing/projects/cups/fuzzer $SRC/cups/ossfuzz/
+cp -r $SRC/fuzzing/projects/cups/fuzzer/. $SRC/cups/ossfuzz/
 popd
 
 # Build CUPS

--- a/projects/libcups/oss_fuzz_build.sh
+++ b/projects/libcups/oss_fuzz_build.sh
@@ -21,7 +21,7 @@ echo "libcups version: $(git rev-parse HEAD)"
 popd
 
 # prepare fuzz dir
-cp -r $SRC/fuzzing/projects/libcups/fuzzer $SRC/libcups/ossfuzz/
+cp -r $SRC/fuzzing/projects/libcups/fuzzer/. $SRC/libcups/ossfuzz/
 
 # build project
 cd $SRC/libcups

--- a/projects/libcupsfilters/oss_fuzz_build.sh
+++ b/projects/libcupsfilters/oss_fuzz_build.sh
@@ -35,7 +35,7 @@ fi
 pushd $SRC/fuzzing/projects/libcupsfilters/
 # Show fuzzer version
 echo "OpenPrinting/fuzzing version: $(git rev-parse HEAD)"
-cp -r $SRC/fuzzing/projects/libcupsfilters/fuzzer $SRC/libcupsfilters/ossfuzz/
+cp -r $SRC/fuzzing/projects/libcupsfilters/fuzzer/. $SRC/libcupsfilters/ossfuzz/
 popd
 
 # Build libcupsfilters


### PR DESCRIPTION
This change improves compatibility with oss-fuzz-gen by avoiding unnecessary nested directories when copying fuzzers.

Previously, oss-fuzz-gen generates a new harness directly inside the fuzzer directory (e.g., `ossfuzz/cups_fuzzer.c`). However, if `build.sh` blindly copies the entire `fuzzer` folder without handling existing contents, it results in an extra nesting level (`ossfuzz/fuzzer/`), which breaks the build.

This PR ensures that only the contents of the `fuzzer/` directory are copied, not the directory itself, maintaining the expected structure.