### PR TITLE
Pyppd: fuzz_parse.py: add instrumentation

### DIFF
--- a/projects/pyppd/fuzzer/fuzz_parse.py
+++ b/projects/pyppd/fuzzer/fuzz_parse.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import atheris
 import sys
 import pyppd.ppd as ppd

--- a/projects/pyppd/fuzzer/fuzz_parse.py
+++ b/projects/pyppd/fuzzer/fuzz_parse.py
@@ -8,9 +8,11 @@ def TestOneInput(data):
     try:
         #fuzz.ppd is a fake file name
         ppd.parse(data, "fuzz.ppd")
-    except (ValueError, KeyError, AttributeError, UnicodeDecodeError):
-        #parsing errors are expected
-        pass
+    except Exception as e:
+        if "Error parsing PPD file" in str(e):
+            pass  #expected parsing error
+        else:
+            raise
 
 def main():
     atheris.Setup(sys.argv, TestOneInput)

--- a/projects/pyppd/fuzzer/fuzz_parse.py
+++ b/projects/pyppd/fuzzer/fuzz_parse.py
@@ -8,7 +8,7 @@ def TestOneInput(data):
     try:
         #fuzz.ppd is a fake file name
         ppd.parse(data, "fuzz.ppd")
-    except Exception:
+    except (ValueError, KeyError, AttributeError, UnicodeDecodeError):
         #parsing errors are expected
         pass
 

--- a/projects/pyppd/fuzzer/fuzz_parse.py
+++ b/projects/pyppd/fuzzer/fuzz_parse.py
@@ -15,6 +15,7 @@ def TestOneInput(data):
             raise
 
 def main():
+    atheris.instrument_all()
     atheris.Setup(sys.argv, TestOneInput)
     atheris.Fuzz()
 

--- a/projects/pyppd/fuzzer/fuzz_parse.py
+++ b/projects/pyppd/fuzzer/fuzz_parse.py
@@ -8,11 +8,9 @@ def TestOneInput(data):
     try:
         #fuzz.ppd is a fake file name
         ppd.parse(data, "fuzz.ppd")
-    except Exception as e:
-        if "Error parsing PPD file" in str(e):
-            pass  #expected parsing error
-        else:
-            raise
+    except Exception:
+        #parsing errors are expected
+        pass
 
 def main():
     atheris.instrument_all()

--- a/projects/pyppd/oss_fuzz_build.sh
+++ b/projects/pyppd/oss_fuzz_build.sh
@@ -13,5 +13,5 @@ for fuzzer in $(find $SRC/fuzzing/projects/pyppd/fuzzer -name 'fuzz_*.py'); do
     cd "$seed_dir" && zip -r "$OUT/${fuzzer_name}_seed_corpus.zip" .
   fi
   
-  compile_python_fuzzer "$fuzzer"
+  compile_python_fuzzer "$fuzzer" --add-data "$SRC/pyppd:pyppd"
 done

--- a/projects/pyppd/oss_fuzz_build.sh
+++ b/projects/pyppd/oss_fuzz_build.sh
@@ -3,6 +3,7 @@
 # build and install pyppd
 cd $SRC/pyppd
 pip3 install .
+python3 setup.py install
 
 # compile all fuzzers with seeds
 for fuzzer in $(find $SRC/fuzzing/projects/pyppd/fuzzer -name 'fuzz_*.py'); do

--- a/projects/pyppd/oss_fuzz_build.sh
+++ b/projects/pyppd/oss_fuzz_build.sh
@@ -13,5 +13,5 @@ for fuzzer in $(find $SRC/fuzzing/projects/pyppd/fuzzer -name 'fuzz_*.py'); do
     cd "$seed_dir" && zip -r "$OUT/${fuzzer_name}_seed_corpus.zip" .
   fi
   
-  compile_python_fuzzer "$fuzzer" --add-data "$SRC/pyppd:pyppd"
+  compile_python_fuzzer "$fuzzer" --hidden-import=pyppd
 done

--- a/projects/pyppd/oss_fuzz_build.sh
+++ b/projects/pyppd/oss_fuzz_build.sh
@@ -3,7 +3,7 @@
 # build and install pyppd
 cd $SRC/pyppd
 pip3 install .
-python3 setup.py install
+# python3 setup.py install
 
 # compile all fuzzers with seeds
 for fuzzer in $(find $SRC/fuzzing/projects/pyppd/fuzzer -name 'fuzz_*.py'); do

--- a/projects/pyppd/seeds/fuzz_parse/seed1.ppd
+++ b/projects/pyppd/seeds/fuzz_parse/seed1.ppd
@@ -1,0 +1,8 @@
+*PPD-Adobe: "4.3"
+*LanguageVersion: English
+*Manufacturer: "TestMfg"
+*NickName: "Test Printer"
+*ModelName: "TestModel"
+*1284DeviceID: "MFG:TestMfg;MDL:TestModel;"
+*Product: "(Test Product)"
+*End


### PR DESCRIPTION
added `atheris.instrument_all()` for instrumenting functions for the fuzz_parse fuzzer
increased coverage from: 0 to 136

before:
```
#2      INITED exec/s: 0 rss: 57Mb
WARNING: no interesting inputs were found so far. Is the code instrumented for coverage?
This may also happen if the target rejected all inputs we tried so far
#262144 pulse  corp: 1/1b lim: 2611 exec/s: 131072 rss: 80Mb
#524288 pulse  corp: 1/1b lim: 4096 exec/s: 104857 rss: 80Mb
```
after:
```
#51081  REDUCE cov: 136 ft: 184 corp: 13/2571b lim: 522 exec/s: 12770 rss: 107Mb L: 142/345 MS: 1 EraseBytes-
#52129  REDUCE cov: 136 ft: 184 corp: 13/2570b lim: 531 exec/s: 10425 rss: 107Mb L: 141/345 MS: 3 ShuffleBytes-PersAutoDict-EraseBytes- DE: "\377\377\377\377"-
#54805  REDUCE cov: 136 ft: 184 corp: 13/2553b lim: 549 exec/s: 10961 rss: 107Mb L: 328/328 MS: 1 EraseBytes-
#55451  REDUCE cov: 136 ft: 184 corp: 13/2552b lim: 549 exec/s: 11090 rss: 107Mb L: 196/328 MS: 1 EraseBytes-
```