### PR TITLE
Fix #5: Add minimal PDF corpus for fuzzpdf target

### DIFF
--- a/corpora/fuzzpdf/README.md
+++ b/corpora/fuzzpdf/README.md
@@ -1,0 +1,4 @@
+# Fuzzing Corpus for PDF
+This directory contains seed files for fuzzing PDF processing in `cups-filters`.
+
+The `minimal.pdf` file is a 3-line valid PDF used as a basic seed to ensure the coverage build does not fail with an empty corpus zip error.

--- a/corpora/fuzzpdf/minimal.pdf
+++ b/corpora/fuzzpdf/minimal.pdf
@@ -1,0 +1,14 @@
+%PDF-1.0
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R/Resources<<>>>>endobj
+xref
+0 4
+0000000000 65535 f 
+0000000010 00000 n 
+0000000070 00000 n 
+0000000120 00000 n 
+trailer<</Size 4/Root 1 0 R>>
+startxref
+204
+%%EOF


### PR DESCRIPTION
Fixes #5

Add a minimal valid PDF seed to `corpora/fuzzpdf/` to resolve the OSS‑Fuzz coverage build failure for the cups‑filters project.

Currently, the coverage build fails with a `zipfile is empty` error because the `fuzzpdf` target lacks any seed files. This minimal (250‑byte) PDF ensures that the corpus zip is non‑empty while keeping the repo size small.